### PR TITLE
Allow command-line block to be indented

### DIFF
--- a/lib/filters/pre/command-line.rb
+++ b/lib/filters/pre/command-line.rb
@@ -1,12 +1,12 @@
 module Filters
   module PreFilter
     def format_command_line(text)
-      text.gsub /\n?``` command-line(.+?)```/m do |block|
-        block.gsub! /^``` command-line/, '<pre class="command-line">'
-        block.gsub! /^```$/, "</pre>\n"
-        block.gsub!(/^\$ (.+)$/) { %(<span class="command">#{$1.rstrip}</span>) }
-        block.gsub!(/^(\# .+)$/) { %(<span class="comment">#{$1.rstrip}</span>) }
-        block.gsub!(/^> (.+)$/) { %(<span class="output">#{$1.rstrip}</span>) }
+      text.gsub /\n?\s*``` command-line(.+?)```/m do |block|
+        block.gsub! /^\s*``` command-line/, '<pre class="command-line">'
+        block.gsub! /^\s*```$/, "</pre>\n"
+        block.gsub!(/^\s*\$ (.+)$/) { %(<span class="command">#{$1.rstrip}</span>) }
+        block.gsub!(/^\s*(\# .+)$/) { %(<span class="comment">#{$1.rstrip}</span>) }
+        block.gsub!(/^\s*> (.+)$/) { %(<span class="output">#{$1.rstrip}</span>) }
 
         block
       end

--- a/test/fixtures/command_line_indented.md
+++ b/test/fixtures/command_line_indented.md
@@ -1,0 +1,6 @@
+    ``` command-line
+    $ git remote add origin https://github.com/<em>user</em>/<em>repo</em>.git
+    # Set a new remote
+    > origin  https://github.com/user/repo.git
+    $ git remote add -f spoon-knife git@github.com:octocat/Spoon-Knife.git
+    ```

--- a/test/test_extended_markdown_filter.rb
+++ b/test/test_extended_markdown_filter.rb
@@ -18,6 +18,19 @@ class HTML::Pipeline::ExtendedMarkdownFilterTest < Minitest::Test
     assert_equal 0, doc.css('.command-line a').size
   end
 
+  def test_command_line_indented
+    doc = ExtendedMarkdownFilter.to_document(fixture("command_line_indented.md"), {})
+    assert doc.kind_of?(HTML::Pipeline::DocumentFragment)
+
+    assert_equal 1, doc.css('pre').size
+    assert_equal 2, doc.css('span.command').size
+    assert_equal 1, doc.css('span.comment').size
+    assert_equal 2, doc.css('em').size
+    assert_equal 1, doc.css('span.output').size
+
+    assert_equal 0, doc.css('.command-line a').size
+  end
+
   def test_helper
     doc = ExtendedMarkdownFilter.to_document(fixture("helper.md"), {})
     assert doc.kind_of?(HTML::Pipeline::DocumentFragment)


### PR DESCRIPTION
Allow a command-line code block to be indented. Prior to this change, an indented block would not close properly and the rest of the page was messed up. Indented code blocks is necessary to continue numbered lists. Now the regex allows zero or more whitespace at the beginning of each line. The change includes tests.

Fixes #13 