### PR TITLE
Fix Command-line highlighting bug

### DIFF
--- a/lib/filters/pre/command-line.rb
+++ b/lib/filters/pre/command-line.rb
@@ -1,7 +1,7 @@
 module Filters
   module PreFilter
     def format_command_line(text)
-      text.gsub /\n?\s*``` command-line(.+?)```/m do |block|
+      text.gsub /^\n?\s*``` command-line(.+?)```/m do |block|
         block.gsub! /^\s*``` command-line/, '<pre class="command-line">'
         block.gsub! /^\s*```$/, "</pre>\n"
         block.gsub!(/^\s*\$ (.+)$/) { %(<span class="command">#{$1.rstrip}</span>) }

--- a/test/fixtures/command_line.md
+++ b/test/fixtures/command_line.md
@@ -1,6 +1,10 @@
+# Header
+
 ``` command-line
 $ git remote add origin https://github.com/<em>user</em>/<em>repo</em>.git
 # Set a new remote
 > origin  https://github.com/user/repo.git
 $ git remote add -f spoon-knife git@github.com:octocat/Spoon-Knife.git
 ```
+
+next paragraph

--- a/test/fixtures/command_line_indented.md
+++ b/test/fixtures/command_line_indented.md
@@ -1,6 +1,10 @@
+# Header
+
     ``` command-line
     $ git remote add origin https://github.com/<em>user</em>/<em>repo</em>.git
     # Set a new remote
     > origin  https://github.com/user/repo.git
     $ git remote add -f spoon-knife git@github.com:octocat/Spoon-Knife.git
     ```
+
+next paragraph

--- a/test/test_extended_markdown_filter.rb
+++ b/test/test_extended_markdown_filter.rb
@@ -16,6 +16,7 @@ class HTML::Pipeline::ExtendedMarkdownFilterTest < Minitest::Test
     assert_equal 1, doc.css('span.output').size
 
     assert_equal 0, doc.css('.command-line a').size
+    refute_equal 0, doc.css('pre').inner_text.length
   end
 
   def test_command_line_indented
@@ -29,6 +30,7 @@ class HTML::Pipeline::ExtendedMarkdownFilterTest < Minitest::Test
     assert_equal 1, doc.css('span.output').size
 
     assert_equal 0, doc.css('.command-line a').size
+    refute_equal 0, doc.css('pre').inner_text.length
   end
 
   def test_helper


### PR DESCRIPTION
This PR is to fix a bug where the regex to match the `command-line` code block incorrectly matches to wider area when there’s a header right above the block.

For example, this markdown

    ``` command-line
    $ git remote add origin https://github.com/<em>user</em>/<em>repo</em>.git
    # Set a new remote
    > origin  https://github.com/user/repo.git
    $ git remote add -f spoon-knife git@github.com:octocat/Spoon-Knife.git
    ```

Is transpiled to this html properly:

```
<pre class="command-line">
<span class="command">git remote add origin https://github.com/<em>user</em>/<em>repo</em>.git</span>
<span class="comment"># Set a new remote</span>
<span class="output">origin  https://github.com/user/repo.git</span>
<span class="command">git remote add -f spoon-knife git@github.com:octocat/Spoon-Knife.git</span>
</pre>
```

However if there's a header just above the code block:

    # Header
    ``` command-line
    $ git remote add origin https://github.com/<em>user</em>/<em>repo</em>.git
    # Set a new remote
    > origin  https://github.com/user/repo.git
    $ git remote add -f spoon-knife git@github.com:octocat/Spoon-Knife.git
    ```

This will be transpiled like this:

```
<h1>Header<pre class="command-line"></pre>
</h1>

<p><span class="command">git remote add origin <a href="https://github.com/">https://github.com/</a><em>user</em>/<em>repo</em>.git</span><br>
<span class="comment"># Set a new remote</span><br>
<span class="output">origin  <a href="https://github.com/user/repo.git">https://github.com/user/repo.git</a></span><br>
<span class="command">git remote add -f spoon-knife <a href="mailto:git@github.com">git@github.com</a>:octocat/Spoon-Knife.git</span><br>
</p>
```

`<pre>` is empty and located inside `<h3>`. `<span class=“output”>` is wrapped by `<p>`.

This happenes because the [regex in L4 of lib/filters/pre/command-line.rb](https://github.com/gjtorikian/extended-markdown-filter/blob/d00e460015b0b82c5a9e34c249c0aa847a42fcbc/lib/filters/pre/command-line.rb#L4) matches from the end of the above line. By adding `^` at the beginning of the regex will fix the problem.

Also I updated the `test_command_line` and `test_command_line_indented` methods in the `test_extended_markdown_filter.rb` to make sure the content length of the `<pre>` tag is not `0` even if there’s a header right above the code block.