### PR TITLE
Update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ rvm:
   - 2.4.0
 
 sudo: false
+
+# we need a more recent cmake than travis/linux provides (at least 2.8.9):
+addons:
+  apt:
+    sources:
+      - kalakris-cmake
+    packages:
+      - cmake
+
 cache: bundler
 git:
   depth: 10

--- a/extended-markdown-filter.gemspec
+++ b/extended-markdown-filter.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'html-pipeline', "~> 2.0"
-  spec.add_dependency 'nokogiri', "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 1.4"
   spec.add_development_dependency "rake"

--- a/extended-markdown-filter.gemspec
+++ b/extended-markdown-filter.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.4"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'minitest', "~> 5.0"
-  spec.add_development_dependency 'github-markdown', "~> 0.6"
+  spec.add_development_dependency 'commonmarker', '~> 0.16.8'
 end

--- a/lib/extended-markdown-filter.rb
+++ b/lib/extended-markdown-filter.rb
@@ -1,6 +1,5 @@
 require 'html/pipeline'
 require 'filters/filters'
-require 'nokogiri'
 require 'jekyll-override' unless defined?(Jekyll).nil?
 
 class ExtendedMarkdownFilter < HTML::Pipeline::MarkdownFilter


### PR DESCRIPTION
This PR updates some dependencies to resolve the following issues:
- It appears that nokogiri logic was removed in 20dad91035a10c84f68608b2b1aba8f32f226153 but the dependency wasn't removed.
- [github-markdown](https://github.com/github/github-markdown) has been deprecated. [html-pipeline](https://github.com/jch/html-pipeline) now [uses commonmarker](https://github.com/jch/html-pipeline/commit/7da08406ac76665765a2ae59faba4638b727c3be).