### PR TITLE
Backport removal of  nokogiri dependencies to 0-4-stable

### DIFF
--- a/extended-markdown-filter.gemspec
+++ b/extended-markdown-filter.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'html-pipeline', "~> 2.0"
-  spec.add_dependency 'nokogiri', "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 1.4"
   spec.add_development_dependency "rake"

--- a/lib/extended-markdown-filter.rb
+++ b/lib/extended-markdown-filter.rb
@@ -1,6 +1,5 @@
 require 'html/pipeline'
 require 'filters/filters'
-require 'nokogiri'
 require 'jekyll-override' unless defined?(Jekyll).nil?
 
 class ExtendedMarkdownFilter < HTML::Pipeline::MarkdownFilter


### PR DESCRIPTION
This is work towards https://github.com/gjtorikian/extended-markdown-filter/issues/22 . It backports https://github.com/gjtorikian/extended-markdown-filter/commit/98daa86600855849e4c1d87bf1960c0c1531a9f3 before the 0.5 release which changes to commonmarker.